### PR TITLE
feat(note): introduce upsertNote create branch

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -81,6 +81,27 @@ REMOVE_SHARE) and the Share intake module. `pages/api/auth.js` and
 `pages/api/public_project.ts` still hand-roll the same populate; folding
 them into this helper is a clean follow-up.
 
+### Architecture (Note seam)
+
+**Note intake**:
+The pair `upsertNote` / `removeDoneProjectNotes` in
+`utils/note/noteIntake.ts` that owns the Project↔Note lifecycle on the
+write path. `upsertNote` decides create-vs-update by
+`Note.findById(input._id)`; on create it pushes the new id onto
+`Project.notes` and returns the Note re-loaded with its author User
+populated. The intake takes a pre-resolved `authorId: string | null` so
+guests skip authorship without the module knowing about
+`OptionalAuthContext`. `removeDoneProjectNotes` deletes every done Note
+in a project and returns the survivors. Handlers no longer reach into
+`Note.findById`, `new Note()`, `Project.findById().notes.push(...)`, or
+`Note.deleteMany` directly.
+
+**extractAuthorId**:
+The one-line helper in `utils/auth/withAuthenticatedUser.ts` that pulls
+`User._id` (or `null`) out of an `OptionalAuthContext`. Centralises the
+Mongoose `Document._id` cast so consumers of the optional-auth seam
+don't repeat it.
+
 ## Relationships
 
 - A **User** owns many **Projects**; a **Project** has one **User**.
@@ -123,8 +144,3 @@ re-suggesting in a future architecture review:
 - **`globalContext.tsx` god-object**: 792 LOC, 28 exposed properties; a
   separate review should consider splitting it along the same seam lines
   used for the API (Identity, Project, Note, Share).
-- **`pages/api/note.ts` action dispatch**: a single handler with both an
-  upsert path (no `action`) and a `REMOVE_DONE_NOTES` branch makes the
-  intake hard to test without exercising the whole route. The Share-seam
-  refactor in `pages/api/project.ts` is the template — extract a Note
-  intake module along the same lines.

--- a/README.md
+++ b/README.md
@@ -54,5 +54,14 @@ Shared-project access goes through `utils/share/sharePassword.ts`:
   `ShareAccessResult` discriminated union: `open` | `passwordRequired` |
   `incorrect` | `ok`.
 
-Both modules have unit tests under `src/__test__/` that exercise behaviour
-through their public interface.
+Note write-path goes through `utils/note/noteIntake.ts`:
+
+- **`upsertNote(input, authorId)`** — used by `pages/api/note.ts`.
+  Creates if `_id` is not found, updates otherwise. On create also
+  attaches the note id to its Project. Pass `null` for `authorId` to
+  skip authorship (guest path).
+- **`removeDoneProjectNotes(projectId)`** — used by the same handler
+  for the `REMOVE_DONE_NOTES` action; returns the surviving notes.
+
+All three modules have unit tests under `src/__test__/` that exercise
+behaviour through their public interface.

--- a/pages/api/note.ts
+++ b/pages/api/note.ts
@@ -1,88 +1,27 @@
 import { StatusCodes } from "http-status-codes";
-import { NextApiResponse } from "next";
 
-import {
-  NoteApiAction,
-  NoteDocInterface,
-  NoteInterface,
-  UserDocInterface,
-} from "@/root/src/components/shared/types";
-import { withOptionalUser } from "@/utils/auth/withAuthenticatedUser";
-import { generateAccessToken } from "@/utils/jwt";
-import { Note, Project } from "@/utils/mongoose";
+import { NoteApiAction, NoteInterface } from "@/root/src/components/shared/types";
+import { extractAuthorId, withOptionalUser } from "@/utils/auth/withAuthenticatedUser";
+import { removeDoneProjectNotes, upsertNote } from "@/utils/note/noteIntake";
 
 export default withOptionalUser(async (req, res, ctx) => {
-  // 'note' is inclusive of projectId
-  const { action, note }: { action: NoteApiAction; note: NoteInterface } = req.body;
+  const { action, note, projectId } = req.body as {
+    action?: NoteApiAction;
+    note?: NoteInterface;
+    projectId?: string;
+  };
+  const authorId = extractAuthorId(ctx);
 
-  // different route if we choose to delete all complete notes from specified project
-  if (action === NoteApiAction.REMOVE_DONE_NOTES) {
-    return await removeDoneNotes(res, ctx.userDoc, req.body.projectId);
-  }
-
-  let noteDoc: NoteDocInterface;
   try {
-    if (!action) {
-      // use _id to search for doc, the rest is data to add
-      const { _id, ...data } = note;
-
-      noteDoc = await Note.findById(_id);
-
-      // if note exists
-      if (noteDoc) {
-        // update user if we have one (in case we have a different user modifying a note)
-        // todo: array of users who modify the note when original 'user' is present?
-        if (!ctx.isGuest) data.user = ctx.userDoc._id as any;
-
-        await noteDoc.updateOne({ $set: data });
-        await noteDoc.save();
-        // assign updated version
-        noteDoc = await Note.findById(noteDoc._id);
-      } else {
-        // create note
-
-        // add user info to note
-        if (!ctx.isGuest) note.user = ctx.userDoc._id as any;
-
-        // create with whole 'note' since we are passing a manually created _id for faster state management client side
-        noteDoc = new Note(note);
-        await noteDoc.save();
-        // add note id to relevant project
-        const projectDoc = await Project.findById(noteDoc.project);
-        projectDoc.notes.push(noteDoc._id);
-        await projectDoc.save();
-      }
+    if (action === NoteApiAction.REMOVE_DONE_NOTES) {
+      const notes = await removeDoneProjectNotes(projectId!);
+      return res.status(StatusCodes.OK).json({ notes, token: ctx.newToken });
     }
+
+    const noteDoc = await upsertNote(note!, authorId);
+    return res.status(StatusCodes.OK).json({ note: noteDoc.toObject(), token: ctx.newToken });
   } catch (error) {
     console.error(error);
     return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ msg: "Database error", error });
   }
-
-  // populate the 'user' field if it is a user created note
-  if (noteDoc.user && !noteDoc.populated("user")) await noteDoc.populate("user", "username email");
-
-  res.status(StatusCodes.OK).json({
-    note: noteDoc.toObject(),
-    token: ctx.newToken,
-  });
 });
-
-const removeDoneNotes = async (
-  res: NextApiResponse,
-  userDoc: UserDocInterface | null,
-  projectId: string,
-): Promise<void> => {
-  console.log("removing completed notes from project:", projectId);
-  // delete all notes which match projectId and are 'done'
-  await Note.deleteMany({ project: projectId, done: true });
-  // return all notes for project
-  const notes = await Note.find({ project: projectId }).lean();
-
-  // token (keep resetting their session length) — guests get null
-  const newToken = userDoc ? generateAccessToken(userDoc.email) : null;
-
-  res.status(StatusCodes.OK).json({
-    notes,
-    token: newToken,
-  });
-};

--- a/src/__test__/note/noteIntake.test.ts
+++ b/src/__test__/note/noteIntake.test.ts
@@ -88,4 +88,29 @@ describe("upsertNote — create path (no existing _id)", () => {
     expect(projectDoc.save).toHaveBeenCalledTimes(1);
     expect(result).toBe(populatedNote);
   });
+
+  it("omits the user field when authorId is null (guest path)", async () => {
+    await upsertNote(buildNoteInput(), null);
+
+    const constructed = vi.mocked(Note).mock.calls[0]![0] as Record<string, unknown>;
+    expect("user" in constructed).toBe(false);
+  });
+
+  it("sets user to the supplied authorId, ignoring any user field in the input", async () => {
+    await upsertNote(buildNoteInput({ user: "stale-from-client" }) as never, "u1");
+
+    const constructed = vi.mocked(Note).mock.calls[0]![0] as Record<string, unknown>;
+    expect(constructed.user).toBe("u1");
+  });
+
+  it("propagates a Project.findById failure (no orphan project save)", async () => {
+    const projectDoc = buildProjectDoc();
+    vi.mocked(Project.findById).mockResolvedValue(projectDoc as never);
+    vi.mocked(Project.findById).mockImplementationOnce(() => {
+      throw new Error("project lookup failed");
+    });
+
+    await expect(upsertNote(buildNoteInput(), "u1")).rejects.toThrow("project lookup failed");
+    expect(projectDoc.save).not.toHaveBeenCalled();
+  });
 });

--- a/src/__test__/note/noteIntake.test.ts
+++ b/src/__test__/note/noteIntake.test.ts
@@ -52,14 +52,21 @@ const populatedNote = {
   user: { _id: "u1", username: "alice", email: "a@a" },
 };
 
-const mockReloadWithAuthor = () => {
-  vi.mocked(Note.findById).mockReturnValue({
-    populate: vi.fn().mockResolvedValue(populatedNote),
-  } as never);
+// upsertNote calls Note.findById twice: first for the existing-doc lookup
+// (returns null on the create path, the doc on the update path), then for
+// the populated reload. Tests prime the first call via `lookup`; the second
+// always resolves to `populatedNote`.
+const primeFindById = (lookup: unknown) => {
+  vi.mocked(Note.findById).mockReset();
+  vi.mocked(Note.findById)
+    .mockReturnValueOnce(lookup as never)
+    .mockReturnValue({
+      populate: vi.fn().mockResolvedValue(populatedNote),
+    } as never);
 };
 
 beforeEach(() => {
-  mockReloadWithAuthor();
+  primeFindById(null);
   vi.mocked(Project.findById).mockResolvedValue(buildProjectDoc() as never);
 });
 
@@ -112,5 +119,49 @@ describe("upsertNote — create path (no existing _id)", () => {
 
     await expect(upsertNote(buildNoteInput(), "u1")).rejects.toThrow("project lookup failed");
     expect(projectDoc.save).not.toHaveBeenCalled();
+  });
+});
+
+type FakeNoteDoc = {
+  _id: string;
+  updateOne: ReturnType<typeof vi.fn>;
+  save: ReturnType<typeof vi.fn>;
+};
+
+const buildExistingNoteDoc = (overrides: Partial<FakeNoteDoc> = {}): FakeNoteDoc => ({
+  _id: "n1",
+  updateOne: vi.fn().mockResolvedValue(undefined),
+  save: vi.fn().mockResolvedValue(undefined),
+  ...overrides,
+});
+
+describe("upsertNote — update path (existing _id)", () => {
+  it("updates the existing note via updateOne+save, never constructs a new Note, and leaves Project.notes alone", async () => {
+    const existingDoc = buildExistingNoteDoc();
+    primeFindById(existingDoc);
+    const projectDoc = buildProjectDoc();
+    vi.mocked(Project.findById).mockResolvedValue(projectDoc as never);
+
+    const result = await upsertNote(buildNoteInput({ content: "edited" }), "u1");
+
+    expect(existingDoc.updateOne).toHaveBeenCalledWith({
+      $set: expect.objectContaining({ content: "edited", user: "u1" }),
+    });
+    expect(existingDoc.save).toHaveBeenCalledTimes(1);
+    expect(Note).not.toHaveBeenCalled();
+    expect(projectDoc.save).not.toHaveBeenCalled();
+    expect(result).toBe(populatedNote);
+  });
+
+  it("does not touch the user field on $set when authorId is null (guest editing)", async () => {
+    const existingDoc = buildExistingNoteDoc();
+    primeFindById(existingDoc);
+
+    await upsertNote(buildNoteInput({ content: "edited" }), null);
+
+    const [{ $set }] = vi.mocked(existingDoc.updateOne).mock.calls[0]! as [
+      { $set: Record<string, unknown> },
+    ];
+    expect("user" in $set).toBe(false);
   });
 });

--- a/src/__test__/note/noteIntake.test.ts
+++ b/src/__test__/note/noteIntake.test.ts
@@ -19,7 +19,7 @@ vi.mock("@/utils/mongoose", () => {
 });
 
 import { Note, Project } from "@/utils/mongoose";
-import { upsertNote } from "@/utils/note/noteIntake";
+import { removeDoneProjectNotes, upsertNote } from "@/utils/note/noteIntake";
 
 type FakeProjectDoc = {
   _id: string;
@@ -163,5 +163,35 @@ describe("upsertNote — update path (existing _id)", () => {
       { $set: Record<string, unknown> },
     ];
     expect("user" in $set).toBe(false);
+  });
+});
+
+describe("removeDoneProjectNotes", () => {
+  it("deletes done notes scoped to the project and returns the survivors", async () => {
+    const survivors = [
+      { _id: "n2", content: "still todo", done: false, project: "p1" },
+      { _id: "n3", content: "still todo too", done: false, project: "p1" },
+    ];
+    vi.mocked(Note.deleteMany).mockResolvedValue({ deletedCount: 1 } as never);
+    vi.mocked(Note.find).mockReturnValue({
+      lean: vi.fn().mockResolvedValue(survivors),
+    } as never);
+
+    const result = await removeDoneProjectNotes("p1");
+
+    expect(Note.deleteMany).toHaveBeenCalledWith({ project: "p1", done: true });
+    expect(Note.find).toHaveBeenCalledWith({ project: "p1" });
+    expect(result).toBe(survivors);
+  });
+
+  it("returns an empty array when no notes remain", async () => {
+    vi.mocked(Note.deleteMany).mockResolvedValue({ deletedCount: 5 } as never);
+    vi.mocked(Note.find).mockReturnValue({
+      lean: vi.fn().mockResolvedValue([]),
+    } as never);
+
+    const result = await removeDoneProjectNotes("p1");
+
+    expect(result).toEqual([]);
   });
 });

--- a/src/__test__/note/noteIntake.test.ts
+++ b/src/__test__/note/noteIntake.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/utils/mongoose", () => {
+  // `new Note(doc)` returns an object with the doc fields plus a stubbed
+  // save(). The constructor itself is a vi.fn so we can assert what it
+  // was called with.
+  const NoteCtor = vi.fn(function (this: Record<string, unknown>, doc: Record<string, unknown>) {
+    Object.assign(this, doc);
+    (this as { save: () => Promise<void> }).save = vi.fn().mockResolvedValue(undefined);
+  });
+  return {
+    Note: Object.assign(NoteCtor, {
+      findById: vi.fn(),
+      find: vi.fn(),
+      deleteMany: vi.fn(),
+    }),
+    Project: { findById: vi.fn() },
+  };
+});
+
+import { Note, Project } from "@/utils/mongoose";
+import { upsertNote } from "@/utils/note/noteIntake";
+
+type FakeProjectDoc = {
+  _id: string;
+  notes: string[];
+  save: ReturnType<typeof vi.fn>;
+};
+
+const buildNoteInput = (overrides: Record<string, unknown> = {}) => ({
+  _id: "n1",
+  content: "hello",
+  time: 12,
+  done: false,
+  project: "p1",
+  ...overrides,
+});
+
+const buildProjectDoc = (overrides: Partial<FakeProjectDoc> = {}): FakeProjectDoc => ({
+  _id: "p1",
+  notes: [],
+  save: vi.fn().mockResolvedValue(undefined),
+  ...overrides,
+});
+
+const populatedNote = {
+  _id: "n1",
+  content: "hello",
+  time: 12,
+  done: false,
+  project: "p1",
+  user: { _id: "u1", username: "alice", email: "a@a" },
+};
+
+const mockReloadWithAuthor = () => {
+  vi.mocked(Note.findById).mockReturnValue({
+    populate: vi.fn().mockResolvedValue(populatedNote),
+  } as never);
+};
+
+beforeEach(() => {
+  mockReloadWithAuthor();
+  vi.mocked(Project.findById).mockResolvedValue(buildProjectDoc() as never);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("upsertNote — create path (no existing _id)", () => {
+  it("creates a new Note from the input, links it to the project, and returns the populated doc", async () => {
+    const projectDoc = buildProjectDoc();
+    vi.mocked(Project.findById).mockResolvedValue(projectDoc as never);
+
+    const result = await upsertNote(buildNoteInput(), "u1");
+
+    expect(Note).toHaveBeenCalledWith(
+      expect.objectContaining({
+        _id: "n1",
+        content: "hello",
+        time: 12,
+        done: false,
+        project: "p1",
+        user: "u1",
+      }),
+    );
+    expect(projectDoc.notes).toEqual(["n1"]);
+    expect(projectDoc.save).toHaveBeenCalledTimes(1);
+    expect(result).toBe(populatedNote);
+  });
+});

--- a/utils/auth/withAuthenticatedUser.ts
+++ b/utils/auth/withAuthenticatedUser.ts
@@ -31,6 +31,14 @@ export type OptionalAuthContext =
   | { isGuest: true; userDoc: null; email: null; newToken: null }
   | { isGuest: false; userDoc: UserDocInterface; email: string; newToken: string };
 
+/**
+ * Pull the caller's User._id out of an {@link OptionalAuthContext}, or `null`
+ * for guests. Centralises the `_id` cast that Mongoose's untyped `Document`
+ * forces on every consumer of `OptionalAuthContext`.
+ */
+export const extractAuthorId = (ctx: OptionalAuthContext): string | null =>
+  ctx.isGuest ? null : (ctx.userDoc._id as unknown as string);
+
 export type AuthenticatedHandler = (
   req: NextApiRequest,
   res: NextApiResponse,

--- a/utils/note/noteIntake.ts
+++ b/utils/note/noteIntake.ts
@@ -18,6 +18,13 @@ export const upsertNote = async (
   const data: Partial<NoteInterface> = { ...rest };
   if (authorId !== null) data.user = authorId;
 
+  const existing = await Note.findById(_id);
+  if (existing) {
+    await existing.updateOne({ $set: data });
+    await existing.save();
+    return reloadWithAuthor(existing._id);
+  }
+
   const noteDoc = new Note({ _id, ...data });
   await noteDoc.save();
 

--- a/utils/note/noteIntake.ts
+++ b/utils/note/noteIntake.ts
@@ -39,8 +39,9 @@ export const upsertNote = async (
  * Delete every done Note in `projectId`; return the surviving notes
  * (lean). Caller owns any guest/auth policy.
  */
-export const removeDoneProjectNotes = async (_projectId: string): Promise<NoteInterface[]> => {
-  throw new Error("not implemented");
+export const removeDoneProjectNotes = async (projectId: string): Promise<NoteInterface[]> => {
+  await Note.deleteMany({ project: projectId, done: true });
+  return Note.find({ project: projectId }).lean() as unknown as Promise<NoteInterface[]>;
 };
 
 const reloadWithAuthor = (noteId: unknown): Promise<NoteDocInterface> =>

--- a/utils/note/noteIntake.ts
+++ b/utils/note/noteIntake.ts
@@ -1,0 +1,40 @@
+import type { NoteDocInterface, NoteInterface } from "@/shared/types";
+import { Note, Project } from "@/utils/mongoose";
+
+/**
+ * Upsert a Note. Creates when no doc with `input._id` exists, updates
+ * otherwise. On create, also pushes the new Note's _id onto
+ * Project.notes so the Project↔Note lifecycle stays in one place.
+ * Returns the Note doc reloaded with its author User populated
+ * (`username email`). `authorId` is the caller's User._id, or `null`
+ * for guests — guests skip authorship without this module knowing
+ * about OptionalAuthContext.
+ */
+export const upsertNote = async (
+  input: NoteInterface,
+  authorId: string | null,
+): Promise<NoteDocInterface> => {
+  const { _id, ...rest } = input;
+  const data: Partial<NoteInterface> = { ...rest };
+  if (authorId !== null) data.user = authorId;
+
+  const noteDoc = new Note({ _id, ...data });
+  await noteDoc.save();
+
+  const projectDoc = await Project.findById(noteDoc.project);
+  projectDoc.notes.push(noteDoc._id);
+  await projectDoc.save();
+
+  return reloadWithAuthor(noteDoc._id);
+};
+
+/**
+ * Delete every done Note in `projectId`; return the surviving notes
+ * (lean). Caller owns any guest/auth policy.
+ */
+export const removeDoneProjectNotes = async (_projectId: string): Promise<NoteInterface[]> => {
+  throw new Error("not implemented");
+};
+
+const reloadWithAuthor = (noteId: unknown): Promise<NoteDocInterface> =>
+  Note.findById(noteId).populate("user", "username email") as unknown as Promise<NoteDocInterface>;


### PR DESCRIPTION
Tracer bullet for the Note intake module mirroring utils/share/shareIntake.ts.
Covers the create path: a Note with no matching _id is constructed from the
input, linked to its Project via Project.notes, and returned re-loaded with
its author User populated. The intake takes a pre-resolved authorId so
guests skip authorship without the module knowing about OptionalAuthContext.

https://claude.ai/code/session_011QwVDNUmhAdB8WYe8JEPfe